### PR TITLE
[IMP] Atualização BRCobranca versão 10.0.0 .

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-slim
+FROM ruby:3.1.2-slim
 MAINTAINER "raphael.valyi@akretion.com"
 
 WORKDIR /usr/src/app
@@ -9,6 +9,10 @@ RUN mkdir -p tmp log && chown app:app tmp log
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential ghostscript git ruby-dev bundler
+
+# Evita erro
+# Warning: the running version of Bundler (2.1.4) is older than the version that created the lockfile (2.3.7). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.7`.
+RUN gem install bundler:2.3.7
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'brcobranca', git: 'https://github.com/akretion/brcobranca.git' 
+gem 'brcobranca', git: 'https://github.com/kivanio/brcobranca.git'
 gem 'grape'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,78 +1,70 @@
 GIT
-  remote: https://github.com/akretion/brcobranca.git
-  revision: 2f058c3f5c38864a321697613eb5db6f2b2309a5
+  remote: https://github.com/kivanio/brcobranca.git
+  revision: 97cc755699fd2643989962dc8820d92c9ffdd82f
   specs:
-    brcobranca (9.2.4)
-      parseline (~> 1.0.3)
-      rghost (~> 0.9)
-      rghost_barcode (~> 0.9)
-      unidecoder (>= 1.1.2)
+    brcobranca (10.0.0)
+      activesupport (>= 5.2.6)
+      parseline (>= 1.0.3)
+      rghost (>= 0.9)
+      rghost_barcode (>= 0.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     builder (3.2.4)
-    concurrent-ruby (1.1.6)
-    dry-configurable (0.11.5)
+    concurrent-ruby (1.1.10)
+    dry-configurable (0.15.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.4, >= 0.4.7)
-      dry-equalizer (~> 0.2)
-    dry-container (0.7.2)
+      dry-core (~> 0.6)
+    dry-container (0.9.0)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.4.9)
+      dry-configurable (~> 0.13, >= 0.13.0)
+    dry-core (0.7.1)
       concurrent-ruby (~> 1.0)
-    dry-equalizer (0.3.0)
-    dry-inflector (0.2.0)
-    dry-logic (1.0.6)
+    dry-inflector (0.2.1)
+    dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.2)
-      dry-equalizer (~> 0.2)
-    dry-types (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
-      dry-core (~> 0.4, >= 0.4.4)
-      dry-equalizer (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    grape (1.3.3)
+    grape (1.6.2)
       activesupport
       builder
       dry-types (>= 1.1)
       mustermann-grape (~> 1.0.0)
       rack (>= 1.3.0)
       rack-accept
-    i18n (1.8.3)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
+    minitest (5.16.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    mustermann-grape (1.0.1)
+    mustermann-grape (1.0.2)
       mustermann (>= 1.0.0)
-    nio4r (2.5.7)
+    nio4r (2.5.8)
     parseline (1.0.3)
-    puma (4.3.8)
+    puma (5.6.4)
       nio4r (~> 2.0)
-    rack (2.2.3)
+    rack (2.2.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rghost (0.9.7)
     rghost_barcode (0.9)
-    ruby2_keywords (0.0.2)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    unidecoder (1.1.2)
-    zeitwerk (2.3.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   brcobranca!
@@ -80,4 +72,4 @@ DEPENDENCIES
   puma
 
 BUNDLED WITH
-   1.16.2
+   2.3.7


### PR DESCRIPTION
Atualização da versão do BRCobranca para a branch master versão 10.0.0 https://github.com/kivanio/brcobranca/commits/master , foi preciso atualizar a versão da imagem docker para a 3.2.1 e recriar o arquivo Gemfile.lock com o bundle.

Recomendo homologar a alteração criando uma nova imagem:

$ git clone -b update-BRCobranca-version-10.0.0 https://github.com/akretion/boleto_cnab_api.git boleto_cnab_api-master
$ cd boleto_cnab_api-master/
$ docker build -t akretion/boleto_cnab_api-master .
Veja se inicia sem erros
$ docker run -ti -p 9292:9292 akretion/boleto_cnab_api-master

Para testar com o Odoo, caso use o docker altere a imagem usada no docker-compose.yml e os testes podem ser feitos tanto na tela quanto usando os dados de demonstração e testes do modulo l10n_br_account_payment_brcobranca https://github.com/OCA/l10n-brazil/tree/14.0/l10n_br_account_payment_brcobranca ( IMPORTANTE esses testes devem ser feitos rodando localmente, no github é feita apenas uma simulação/mock ).

Por enquanto, rodando os testes do modulo, existe apenas um erro na criação do Boleto Unicred 400 por faltar enviar o Digito da Conta no dicionario, assim que for feito o PR vou marca-lo aqui.