### PR TITLE
[UPD] Atualiza imagem Docker Debian Ruby 3.3.2 e GEMs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.0-slim
+FROM ruby:3.3.2-slim
 MAINTAINER "raphael.valyi@akretion.com"
 
 WORKDIR /usr/src/app
@@ -10,7 +10,11 @@ RUN mkdir -p tmp log && chown app:app tmp log
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential ghostscript git ruby-dev bundler
 
-RUN gem install bundler:2.4.18
+RUN gem install bundler:2.5.11 --no-document \
+   && bundle install --quiet \
+   && rm -rf /usr/local/bundle/cache/*.gem \
+   && find /usr/local/bundle/gems/ -name "*.c" -delete \
+   && find /usr/local/bundle/gems/ -name "*.o" -delete
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@ source 'https://rubygems.org'
 gem 'brcobranca', git: 'https://github.com/kivanio/brcobranca.git'
 gem 'grape'
 gem 'puma'
+gem 'base64'
+gem 'mutex_m'
+gem 'bigdecimal'
+# Erro na versão 0.9.9 https://github.com/shairontoledo/rghost/issues/75
+gem 'rghost', git: 'https://github.com/shairontoledo/rghost.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,60 +6,62 @@ GIT
       activesupport (>= 5.2.6)
       fast_blank
       parseline (>= 1.0.3)
-      rghost (>= 0.9.8)
+      rghost
       rghost_barcode (>= 0.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
+    activesupport (7.1.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     builder (3.2.4)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.1)
     dry-container (0.11.0)
       concurrent-ruby (~> 1.0)
-    dry-core (0.8.1)
+    dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
-    dry-inflector (0.3.0)
-    dry-logic (1.2.0)
+    dry-inflector (1.0.0)
+    dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
-    dry-types (1.5.1)
+    dry-types (1.7.2)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
     fast_blank (1.0.1)
-    grape (1.6.2)
-      activesupport
+    grape (2.0.0)
+      activesupport (>= 5)
       builder
       dry-types (>= 1.1)
       mustermann-grape (~> 1.0.0)
       rack (>= 1.3.0)
       rack-accept
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.19.0)
+    minitest (5.23.1)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    mustermann-grape (1.0.2)
+    mustermann-grape (1.1.0)
       mustermann (>= 1.0.0)
-    nio4r (2.7.0)
+    nio4r (2.7.3)
     parseline (1.0.3)
     puma (6.4.2)
       nio4r (~> 2.0)
-    rack (3.0.9.1)
+    rack (3.0.11)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rghost (0.9.8)
     rghost_barcode (0.9)
     ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    base64 (0.2.0)
+    mutex_m (0.2.0)
+    bigdecimal (3.1.8)
 
 PLATFORMS
   ruby
@@ -68,6 +70,10 @@ DEPENDENCIES
   brcobranca!
   grape
   puma
+  base64
+  mutex_m
+  bigdecimal
+  rghost 'https://github.com/shairontoledo/rghost.git'
 
 BUNDLED WITH
-   2.4.18
+   2.5.11

--- a/README.md
+++ b/README.md
@@ -146,17 +146,18 @@ root@f265658f13ab:/usr/local/bundle/bundler/gems/brcobranca-7bad3e5da8f6# vim li
 
 Se for preciso podemos acompanhar o LOG para ver se há algum erro ou para verificar "imprimindo" o valor de alguma variável com o comando "puts"(https://www.codesdope.com/ruby-putsputsputs/) é possível em outra aba ou terminal rodar o comando
 ```bash
-$ docker logs -f f265658f13ab
+$ docker run -ti -p 9292:9292 akretion/boleto_cnab_api-3_3_2_slim
 Puma starting in single mode...
-* Puma version: 5.6.5 (ruby 3.2.0-p0) ("Birdie's Version")
+* Puma version: 6.4.2 (ruby 3.3.2-p78) ("The Eagle of Durango")
 *  Min threads: 0
 *  Max threads: 5
 *  Environment: development
-*          PID: 7
-/usr/local/bundle/gems/rack-3.0.6.1/lib/rack/auth/digest.rb:8: warning: Rack::Auth::Digest is deprecated and will be removed in Rack 3.1
+*          PID: 6
 * Listening on http://0.0.0.0:9292
 Use Ctrl-C to stop
-
+^C- Gracefully stopping, waiting for requests to finish
+=== puma shutdown: 2024-06-07 15:28:38 +0000 ===
+- Goodbye!
 ```
 
 IMPORTANTE: por algum motivo as alterações dentro do container só tem efeito na primeira vez que o arquivo é Salvo, uma segunda alteração não tem efeito, isso pode ser algo referente ao comportamento da imagem, ou do docker ou do docker-compose, já que nos testes realizados esse container é iniciado e usado por outro container rodando o Odoo, é preciso investigar melhor para entender se isso é algo normal e já esperado ou se teria uma forma de corrigir, porque devido a isso para testar dessa forma está sendo necessário alterar uma vez e se for preciso fazer outra alteração sair do container fazer um kill e inicia-lo novamente.


### PR DESCRIPTION
Atualiza imagem Docker Ruby 3.3.2 e GEMs, com isso limpa o LOG de mensagens sobre bibliotecas ou comandos desatualizados 

* grape (2.0.0) deixa de aparecer a mensagem no LOG
```
/usr/local/bundle/gems/rack-3.0.9.1/lib/rack/auth/digest.rb:8: warning: Rack::Auth::Digest is deprecated and will be removed in Rack 3.1
```
Ao testar com versões RC é possível ver outras mensagens:

```
/usr/local/bundle/gems/rack-3.0.9.1/lib/rack/auth/basic.rb:5: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of rack-3.0.9.1 to add base64 into its gemspec.
/usr/local/bundle/gems/rack-3.0.9.1/lib/rack/auth/digest.rb:8: warning: Rack::Auth::Digest is deprecated and will be removed in Rack 3.1
/usr/local/bundle/gems/activesupport-7.0.7.2/lib/active_support/notifications/fanout.rb:3: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.7.2 to add mutex_m into its gemspec.
/usr/local/bundle/gems/dry-types-1.5.1/lib/dry/types.rb:3: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of dry-types-1.5.1 to add bigdecimal into its gemspec.
```

Ou em algumas verões passa a retornar erro

```
/usr/local/bundle/gems/rack-3.0.9.1/lib/rack/auth/basic.rb:5: warning: base64 was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
! Unable to load application: LoadError: cannot load such file -- base64
bundler: failed to load command: puma (/usr/local/bundle/bin/puma)
```

Foi preciso incluir as gem 'base64', 'mutex_m' 'bigdecimal' com isso o LOG fica limpo
```
$ docker run -ti -p 9292:9292 akretion/boleto_cnab_api-3_3_2_slim
Puma starting in single mode...
* Puma version: 6.4.2 (ruby 3.3.2-p78) ("The Eagle of Durango")
*  Min threads: 0
*  Max threads: 5
*  Environment: development
*          PID: 6
* Listening on http://0.0.0.0:9292
Use Ctrl-C to stop
^C- Gracefully stopping, waiting for requests to finish
=== puma shutdown: 2024-06-07 15:28:38 +0000 ===
- Goodbye!
```

Existe um erro ao atualizar a lib rghost de 0.9.8 para 0.9.9 
```
odoo.exceptions.UserError: b"Puma caught this error: uninitialized constant RGhost::VERSION (NameError)\n/usr/local/bundle/gems/rghost-0.9.9/lib/rghost/document.rb:90:in 'RGhost::Document#initialize'\n/usr/local/bundle/bundler/gems/brcobranca-cd928e87554b/lib/brcobranca/boleto/template/rghost.rb:102:in 'Class#new'\n/usr/local/bundle/bundler/gems/brcobranca-cd928e87554b/lib/brcobranca/boleto/template/rghost.rb:102:in 'Brcobranca::Boleto::Template::Rghost#modelo_generico_multipage'\n/usr/local/bundle/bundler/gems/brcobranca-cd928e87554b/lib/brcobranca/boleto/template/rghost.rb:44:in 'Brcobranca::Boleto::Template::Rghost#lote'\n/usr/src/app/lib/boleto_api.rb:118:in 'block (2 levels) in <class:Server>
```
pelo teste o problema foi resolvido aqui https://github.com/shairontoledo/rghost/commit/94ace8039989228a1a9ba7cd8ae44184b191c9dd mas está na branch master então é preciso mudar para instalar pelo o git.

Tem um aviso durante o docker build a ser resolvido
nil versions are discouraged and will be deprecated in Rubygems 4 

Testes com projeto da localização ( l10n_br_account_payment_brcobranca ) e geração do Boleto PDF

![image](https://github.com/akretion/boleto_cnab_api/assets/6341149/6c367865-386b-46b6-8075-9caf30212d80)

Importante, parece tudo certo, mas recomendo criar uma imagem de teste e validar a alteração.

cc @rvalyi @renatonlima 
 