### PR TITLE
[UPD] Atualizando OS Alpine 3.20.2, README com informações sobre o Alpine e padronização do Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.20.0
-MAINTAINER "raphael.valyi@akretion.com"
+FROM alpine:latest
+LABEL org.opencontainers.image.authors="raphael.valyi@akretion.com"
 
 WORKDIR /usr/src/app
 COPY . .
@@ -28,4 +28,4 @@ RUN bundle config --global frozen 1 && bundle install
 
 EXPOSE 9292
 USER app
-CMD bundle exec puma config.ru
+CMD ["bundle", "exec", "puma", "config.ru"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/kivanio/brcobranca.git
-  revision: cd928e87554bcd9eceadea6cf5a9a777f756b1b8
+  revision: a846c103eeefb5d7bc5d7f35c0b493366622425c
   specs:
-    brcobranca (11.0.0)
+    brcobranca (11.1.0)
       fast_blank
       parseline (>= 1.0.3)
       rghost (>= 0.9.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,81 +3,90 @@ GIT
   revision: cd928e87554bcd9eceadea6cf5a9a777f756b1b8
   specs:
     brcobranca (11.0.0)
-      activesupport (>= 5.2.6)
       fast_blank
       parseline (>= 1.0.3)
-      rghost
+      rghost (>= 0.9.8)
       rghost_barcode (>= 0.9)
+
+GIT
+  remote: https://github.com/shairontoledo/rghost.git
+  revision: 93240b15141abd9be961ab7b1c68c77fc445e4e7
+  specs:
+    rghost (0.9.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
-      base64 (>= 0)
-      drb (>= 0)
-      mutex_m (>= 0)
-    builder (3.2.4)
-    concurrent-ruby (1.3.1)
-    dry-container (0.11.0)
-      concurrent-ruby (~> 1.0)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
-    dry-inflector (1.0.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (1.1.0)
     dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.5, >= 0.5)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
     dry-types (1.7.2)
+      bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
-      dry-container (~> 0.3)
-      dry-core (~> 0.5, >= 0.5)
-      dry-inflector (~> 0.1, >= 0.1.2)
-      dry-logic (~> 1.0, >= 1.0.2)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     fast_blank (1.0.1)
-    grape (2.0.0)
-      activesupport (>= 5)
-      builder
+    grape (2.2.0)
+      activesupport (>= 6)
       dry-types (>= 1.1)
-      mustermann-grape (~> 1.0.0)
-      rack (>= 1.3.0)
-      rack-accept
-    i18n (1.14.5)
+      mustermann-grape (~> 1.1.0)
+      rack (>= 2)
+      zeitwerk
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    minitest (5.23.1)
-    mustermann (3.0.0)
+    logger (1.6.1)
+    minitest (5.25.1)
+    mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.1.0)
       mustermann (>= 1.0.0)
+    mutex_m (0.2.0)
     nio4r (2.7.3)
     parseline (1.0.3)
-    puma (6.4.2)
+    puma (6.4.3)
       nio4r (~> 2.0)
-    rack (3.0.11)
-    rack-accept (0.4.5)
-      rack (>= 0.4)
+    rack (3.1.7)
     rghost_barcode (0.9)
     ruby2_keywords (0.0.5)
+    securerandom (0.3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    base64 (0.2.0)
-    mutex_m (0.2.0)
-    bigdecimal (3.1.8)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
+  bigdecimal
   brcobranca!
   grape
-  puma
-  base64
   mutex_m
-  bigdecimal
-  rghost 'https://github.com/shairontoledo/rghost.git'
+  puma
+  rghost!
 
 BUNDLED WITH
    2.5.11


### PR DESCRIPTION
Atualizando OS Alpine 3.20.2, README com informações sobre o Alpine e padronização do Dockerfile

Parece que em versões recentes o Docker está retornando Warning devido alguns parâmetros, ao fazer um build com debug

$ docker --debug build ..........

está retornando 

```bash
 2 warnings found:
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 2)
The MAINTAINER instruction is deprecated, use a label instead to define an image author
More info: https://docs.docker.com/go/dockerfile/rule/maintainer-deprecated/
Dockerfile:2
--------------------
   1 |     FROM alpine:3.20.0
   2 | >>> MAINTAINER "raphael.valyi@akretion.com"
   3 |     
   4 |     WORKDIR /usr/src/app
--------------------

 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 31)
JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
Dockerfile:31
--------------------
  29 |     EXPOSE 9292
  30 |     USER app
  31 | >>> CMD bundle exec puma config.ru
  32 |     
--------------------

```

Segui as referencias que retorna 
https://docs.docker.com/reference/build-checks/maintainer-deprecated/
https://docs.docker.com/reference/build-checks/json-args-recommended/

cc @rvalyi 
